### PR TITLE
58 upload fip file directly

### DIFF
--- a/EPNDCS1_FIP/fip.ttl
+++ b/EPNDCS1_FIP/fip.ttl
@@ -20,7 +20,7 @@ local:myFip rdf:type fip:FIP-Declaration;
         sio:SIO_000628 <https://repo.metadatacenter.org/templates/cda2f30a-6b9c-4210-a87d-be78a416fdd4>;
     ];
     fip:declares-current-use-of [
-        sh:shapesGraph <https://raw.githubusercontent.com/MaastrichtU-CDS/EPND-FAIRification/case-study-1/EPNDCS1shacl.ttl>;
+        sh:shapesGraph <https://raw.githubusercontent.com/MaastrichtU-CDS/EPND-FAIRification/main/EPNDCS1shacl.ttl>;
     ].
 
 <https://repo.metadatacenter.org/templates/cda2f30a-6b9c-4210-a87d-be78a416fdd4> schema:distribution [

--- a/management_webpage/flaskr/fip_controller.py
+++ b/management_webpage/flaskr/fip_controller.py
@@ -27,15 +27,16 @@ def index():
 
 def __parse_fip(fip_uri):
     try:
-        g = rdflib.Graph()
-        if not re.compile(r"\.ttl$"):
+        r1 = re.compile(r"\.ttl$")
+        if not r1.match(fip_uri):
             np_service = nanopub_service.NanopubService(fip_uri)
             fip_uri = np_service.parse_shacl_uri()
+        g = rdflib.Graph()
         g.parse(fip_uri, format="turtle")
-        print(g)
+
     except Exception as e:
         raise Exception("Could not load the FIP file at %s - Is the URL\
-                        correct?" % fip_uri_updated)
+                        correct?" % fip_uri)
     
     triples = g.serialize(format="turtle")
 

--- a/management_webpage/flaskr/fip_controller.py
+++ b/management_webpage/flaskr/fip_controller.py
@@ -4,6 +4,7 @@ from flask import (
 import validators
 from flaskr.services import fip_service, triplestore, nanopub_service
 import rdflib
+import re
 
 bp = Blueprint("fip_controller",__name__)
 rdfStore = None
@@ -26,10 +27,11 @@ def index():
 
 def __parse_fip(fip_uri):
     try:
-        np_service = nanopub_service.NanopubService(fip_uri)
-        fip_uri_updated = np_service.parse_shacl_uri()
         g = rdflib.Graph()
-        g.parse(fip_uri_updated, format="turtle")
+        if not re.compile(r"\.ttl$"):
+            np_service = nanopub_service.NanopubService(fip_uri)
+            fip_uri = np_service.parse_shacl_uri()
+        g.parse(fip_uri, format="turtle")
         print(g)
     except Exception as e:
         raise Exception("Could not load the FIP file at %s - Is the URL\

--- a/management_webpage/flaskr/fip_controller.py
+++ b/management_webpage/flaskr/fip_controller.py
@@ -2,7 +2,7 @@ from flask import (
     Blueprint, render_template, request, redirect, url_for, current_app
 )
 import validators
-from flaskr.services import fip_service, triplestore
+from flaskr.services import fip_service, triplestore, nanopub_service
 import rdflib
 
 bp = Blueprint("fip_controller",__name__)
@@ -26,10 +26,14 @@ def index():
 
 def __parse_fip(fip_uri):
     try:
+        np_service = nanopub_service.NanopubService(fip_uri)
+        fip_uri_updated = np_service.parse_shacl_uri()
         g = rdflib.Graph()
-        g.parse(fip_uri, format="turtle")
+        g.parse(fip_uri_updated, format="turtle")
+        print(g)
     except Exception as e:
-        raise Exception("Could not load the FIP file at %s - Is the URL correct?" % fip_uri)
+        raise Exception("Could not load the FIP file at %s - Is the URL\
+                        correct?" % fip_uri_updated)
     
     triples = g.serialize(format="turtle")
 

--- a/management_webpage/flaskr/fip_controller.py
+++ b/management_webpage/flaskr/fip_controller.py
@@ -32,17 +32,14 @@ def __parse_fip(fip_uri):
         if not fip_uri.endswith('.ttl', -4):
             np_service = nanopub_service.NanopubService(fip_uri)
             fip_uri = np_service.parse_shacl_uri()
-            print(fip_uri)
     try:
         g = rdflib.Graph()
         g.parse(fip_uri, format='turtle')
-        print(g) 
     except Exception as e:
         raise Exception("Could not load the FIP file at %s - Is the URL\
                             correct?" % fip_uri)
     
     triples = g.serialize(format="turtle")
-    print(triples)
     fService = __get_fip_service()
     fService.load_fip(fip_uri, triples)
     fService.cache_shacl()

--- a/management_webpage/flaskr/fip_controller.py
+++ b/management_webpage/flaskr/fip_controller.py
@@ -32,15 +32,17 @@ def __parse_fip(fip_uri):
         if not fip_uri.endswith('.ttl', -4):
             np_service = nanopub_service.NanopubService(fip_uri)
             fip_uri = np_service.parse_shacl_uri()
+            print(fip_uri)
     try:
         g = rdflib.Graph()
         g.parse(fip_uri, format='turtle')
-    
+        print(g) 
     except Exception as e:
         raise Exception("Could not load the FIP file at %s - Is the URL\
                             correct?" % fip_uri)
     
     triples = g.serialize(format="turtle")
+    print(triples)
     fService = __get_fip_service()
     fService.load_fip(fip_uri, triples)
     fService.cache_shacl()

--- a/management_webpage/flaskr/services/nanopub_service.py
+++ b/management_webpage/flaskr/services/nanopub_service.py
@@ -6,22 +6,27 @@ class NanopubService:
     def __init__(self, uri):
         self.uri = uri
 
+    def fetch_np(self, np): 
+        try:
+            np_parsed = Nanopub(np)
+        except ConnectionError as e:
+            raise Exception("Connection refused by server,\
+                    please try after a while")
+        return np_parsed
+
     def parse_shacl_uri(self):
-        np = Nanopub(self.uri)
+        np = self.fetch_np(self.uri)
         for s, p, o in np.assertion:
-            for s1, p1, o1 in Nanopub(o).assertion:
+            for s1, p1, o1 in self.fetch_np(o).assertion:
                 if o1 ==\
                 URIRef("https://w3id.org/fair/fip/terms/FIP-Question-I2-D")\
                 and\
                 p1 ==\
                 URIRef("https://w3id.org/fair/fip/terms/refers-to-question"):
-                    for s2, p2, o2 in Nanopub(o).assertion:
+                    for s2, p2, o2 in self.fetch_np(o).assertion:
                         if p2 ==\
                         URIRef("https://w3id.org/fair/fip/terms/declares-planned-use-of"):
-                            for s3, p3, o3 in Nanopub(re.split('#',
-                                                               o2)[0]).assertion:
-                                if p3 ==\
-                                URIRef("http://www.w3.org/2000/01/rdf-schema#seeAlso"):
-                                    #return o1
-                                    return \
-                                "https://raw.githubusercontent.com/MaastrichtU-CDS/EPND-FAIRification/main/fip/fip.ttl"
+                            o2_parsed = re.split('#', o2)[0]
+                            for s3, p3, o3 in self.fetch_np(o2_parsed).assertion:
+                                if p3 == URIRef("http://www.w3.org/2000/01/rdf-schema#seeAlso"):
+                                    return o3 

--- a/management_webpage/flaskr/services/nanopub_service.py
+++ b/management_webpage/flaskr/services/nanopub_service.py
@@ -30,4 +30,57 @@ class NanopubService:
                             for s3, p3, o3 in self.fetch_np(o2_parsed).assertion:
                                 if p3 ==\
                                 URIRef("http://usefulinc.com/ns/doap#implements"):
-                                    return o3 
+                                    shacl_uri = o3
+                                    break
+                if o1 ==\
+                URIRef("https://w3id.org/fair/fip/terms/FIP-Question-I3-MD")\
+                and p1 ==\
+                URIRef("https://w3id.org/fair/fip/terms/refers-to-question"):
+                    for s2, p2, o2 in self.fetch_np(o).assertion:
+                        if p2 ==\
+                        URIRef("https://w3id.org/fair/fip/terms/declares-planned-use-of"):
+                            o2_parsed = re.split('#', o2)[0]
+                            for s3, p3, o3 in\
+                            self.fetch_np(o2_parsed).assertion:
+                                if p3 ==\
+                                        URIRef("http://usefulinc.com/ns/doap#implements"):
+                                            cedar_uri = o3
+                                            break
+        if shacl_uri and cedar_uri:
+            fip_uri = self.create_fip_uri(shacl_uri, cedar_uri)
+            return fip_uri
+
+    def create_fip_uri(self, shacl_uri, cedar_uri):
+        base_fip = """
+        @prefix local: <#> .
+        @prefix fip: <https://w3id.org/fair/fip/terms/> .
+        @prefix dash: <http://datashapes.org/dash#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+        @prefix sio: <http://semanticscience.org/resource/>.
+        @prefix snomed: <http://purl.bioontology.org/ontology/SNOMEDCT/>.
+        @prefix UO: <http://purl.obolibrary.org/obo/>.
+        @prefix sty: <http://purl.bioontology.org/ontology/STY/>.
+        @prefix loinc: <http://purl.bioontology.org/ontology/LNC/>.
+        @prefix sh: <http://www.w3.org/ns/shacl#>.
+        @prefix schema: <https://schema.org/>.
+
+        local:myFip rdf:type fip:FIP-Declaration;
+                    rdfs:label "EPND use case 1 ATN";
+                    fip:declares-current-use-of [
+                        rdf:type <https://schema.metadatacenter.org/core/Template>;
+                        sio:SIO_000628 <https://repo.metadatacenter.org/templates/cda2f30a-6b9c-4210-a87d-be78a416fdd4>;
+                    ];
+                    fip:declares-current-use-of [
+                        sh:shapesGraph <shacl_uri>;
+                     ].
+
+        <https://repo.metadatacenter.org/templates/cda2f30a-6b9c-4210-a87d-be78a416fdd4> schema:distribution [
+                schema:encodingFormat "application/ld+json";
+                schema:contentUrl <cedar_uri>;
+        ]."""
+        base_fip = base_fip.replace('shacl_uri', shacl_uri)
+        return base_fip.replace('cedar_uri', cedar_uri)
+

--- a/management_webpage/flaskr/services/nanopub_service.py
+++ b/management_webpage/flaskr/services/nanopub_service.py
@@ -1,0 +1,27 @@
+from nanopub import Nanopub
+from rdflib import URIRef 
+import re
+
+class NanopubService:
+    def __init__(self, uri):
+        self.uri = uri
+
+    def parse_shacl_uri(self):
+        np = Nanopub(self.uri)
+        for s, p, o in np.assertion:
+            for s1, p1, o1 in Nanopub(o).assertion:
+                if o1 ==\
+                URIRef("https://w3id.org/fair/fip/terms/FIP-Question-I2-D")\
+                and\
+                p1 ==\
+                URIRef("https://w3id.org/fair/fip/terms/refers-to-question"):
+                    for s2, p2, o2 in Nanopub(o).assertion:
+                        if p2 ==\
+                        URIRef("https://w3id.org/fair/fip/terms/declares-planned-use-of"):
+                            for s3, p3, o3 in Nanopub(re.split('#',
+                                                               o2)[0]).assertion:
+                                if p3 ==\
+                                URIRef("http://www.w3.org/2000/01/rdf-schema#seeAlso"):
+                                    #return o1
+                                    return \
+                                "https://raw.githubusercontent.com/MaastrichtU-CDS/EPND-FAIRification/main/fip/fip.ttl"

--- a/management_webpage/flaskr/services/nanopub_service.py
+++ b/management_webpage/flaskr/services/nanopub_service.py
@@ -28,5 +28,6 @@ class NanopubService:
                         URIRef("https://w3id.org/fair/fip/terms/declares-planned-use-of"):
                             o2_parsed = re.split('#', o2)[0]
                             for s3, p3, o3 in self.fetch_np(o2_parsed).assertion:
-                                if p3 == URIRef("http://www.w3.org/2000/01/rdf-schema#seeAlso"):
+                                if p3 ==\
+                                URIRef("http://usefulinc.com/ns/doap#implements"):
                                     return o3 

--- a/management_webpage/flaskr/services/triplestore.py
+++ b/management_webpage/flaskr/services/triplestore.py
@@ -117,8 +117,7 @@ class GraphDBTripleStore(AbstractTripleStore):
     def upload_turtle(self, turtleString, namedGraph):
         url = self.endpoint + "/rdf-graphs/service?graph=" + namedGraph
         response = requests.post(url, data=turtleString, headers={"Content-Type": "text/turtle"})
-        
-        if response.status_code > 299 | response.status_code < 200:
+        if response.status_code > 299 or response.status_code < 200:
             print("url: " + url)
             print("data: " + turtleString)
             print(response.text)

--- a/management_webpage/flaskr/templates/fip/index.html
+++ b/management_webpage/flaskr/templates/fip/index.html
@@ -5,12 +5,20 @@
 <div class="d-flex justify-content-center"><img src="/static/EPND_logo_Primary_RGB_2x-100.jpg"  style="margin-bottom: 50px;" height="100"></div>
 
 <h2>Select FIP</h2>
-<p>Enter the URL for the FAIR implementation profile you want to use below.</p>
+<div>
+<button class="btn btn-primary float-left" onclick="getElementById('upload-file').style.display='none'; getElementById('upload-web').style.display='block'">Web</button> 
+<button class="btn btn-primary float-left" onclick="getElementById('upload-web').style.display='none'; getElementById('upload-file').style.display='block'">File upload</button> 
+</div>
 
-<form method="POST">
-    <div class="form-group">
-        <input type="text" class="form-control input-lg" id="fip-uri" name="fip-uri" placeholder="Enter FIP URL">
-        <small id="fip-uri-help" class="form-text text-muted">This URL is given by the project consortium</small>
+<form method="POST" enctype="multipart/form-data">
+    <div class="form-group" style="margin-top: 20px;">
+	    <div id="upload-web" style="display: none;">
+        	<input type="text" class="form-control input-lg" id="fip-uri" name="fip-uri" placeholder="Enter the URL for the FAIR implementation profile you want to use">
+        	<small id="fip-uri-help" class="form-text text-muted">This URL is given by the project consortium</small>
+	    </div>
+	    <div id="upload-file" style="display: none;">
+		<input type="file" name="fip-file" id="fip-file" accept=".ttl">
+	    </div>
         {% if warning %}
         <div class="alert alert-danger alert-dismissible" role="alert">
             {{ warning }}

--- a/management_webpage/requirements.txt
+++ b/management_webpage/requirements.txt
@@ -7,3 +7,4 @@ click==8.0.4
 validators==0.19.0
 requests==2.27.1
 tzlocal==4.2
+nanopub==2.0.0


### PR DESCRIPTION
This pull caters two things - 

1. FIP parsing through nanopub link (not the best way of parsing but does the job for now)
2. Local file upload (file here means "fip file") - This is arguable because we might want to upload even the cedar template and shacl file from local. While shacl loads fine, cedar template loading fails in such cases.